### PR TITLE
Use block state providers for map configuration

### DIFF
--- a/src/main/java/net/gegy1000/spleef/game/SpleefActive.java
+++ b/src/main/java/net/gegy1000/spleef/game/SpleefActive.java
@@ -14,9 +14,9 @@ import net.gegy1000.plasmid.game.rule.GameRule;
 import net.gegy1000.plasmid.game.rule.RuleResult;
 import net.gegy1000.plasmid.util.ItemStackBuilder;
 import net.gegy1000.spleef.game.map.SpleefMap;
+import net.minecraft.block.BlockState;
 import net.minecraft.enchantment.Enchantments;
 import net.minecraft.entity.damage.DamageSource;
-import net.minecraft.item.ItemStack;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
@@ -179,13 +179,15 @@ public final class SpleefActive {
         this.spawnLogic.resetPlayer(player, GameMode.ADVENTURE);
         this.spawnLogic.spawnPlayer(player);
 
-        ItemStack shovel = ItemStackBuilder.of(this.config.tool)
+        ItemStackBuilder shovelBuilder = ItemStackBuilder.of(this.config.tool)
                 .setUnbreakable()
-                .addEnchantment(Enchantments.EFFICIENCY, 2)
-                .addCanDestroy(this.config.map.floor.getBlock())
-                .build();
+                .addEnchantment(Enchantments.EFFICIENCY, 2);
 
-        player.inventory.insertStack(shovel);
+        for (BlockState state : this.map.providedFloors) {
+            shovelBuilder.addCanDestroy(state.getBlock());
+        }
+
+        player.inventory.insertStack(shovelBuilder.build());
     }
 
     private void eliminatePlayer(ServerPlayerEntity player) {

--- a/src/main/java/net/gegy1000/spleef/game/map/SpleefMap.java
+++ b/src/main/java/net/gegy1000/spleef/game/map/SpleefMap.java
@@ -15,10 +15,11 @@ import net.minecraft.world.gen.chunk.ChunkGenerator;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 public final class SpleefMap {
     private final MapTemplate template;
-    private final SpleefMapConfig config;
+    public final Set<BlockState> providedFloors;
 
     private final List<BlockBounds> levels = new ArrayList<>();
     private int topLevel;
@@ -27,9 +28,9 @@ public final class SpleefMap {
 
     private BlockPos spawn = BlockPos.ORIGIN;
 
-    public SpleefMap(MapTemplate template, SpleefMapConfig config) {
+    public SpleefMap(MapTemplate template, Set<BlockState> providedFloors) {
         this.template = template;
-        this.config = config;
+        this.providedFloors = providedFloors;
     }
 
     public void addLevel(BlockBounds bounds) {
@@ -62,7 +63,7 @@ public final class SpleefMap {
     }
 
     public void tryBeginDecayAt(ServerWorld world, BlockPos pos, int timer) {
-        if (world.getBlockState(pos) == this.config.floor) {
+        if (this.providedFloors.contains(world.getBlockState(pos))) {
             this.decayPositions.putIfAbsent(pos.asLong(), timer);
         }
     }
@@ -81,7 +82,7 @@ public final class SpleefMap {
     private void deleteLevel(ServerWorld world, BlockBounds level) {
         for (BlockPos pos : level.iterate()) {
             BlockState state = world.getBlockState(pos);
-            if (state == this.config.floor) {
+            if (this.providedFloors.contains(state)) {
                 world.setBlockState(pos, Blocks.AIR.getDefaultState());
             }
         }

--- a/src/main/java/net/gegy1000/spleef/game/map/SpleefMapConfig.java
+++ b/src/main/java/net/gegy1000/spleef/game/map/SpleefMapConfig.java
@@ -15,6 +15,7 @@ public final class SpleefMapConfig {
                 Codec.INT.fieldOf("level_height").forGetter(map -> map.levelHeight),
                 BlockStateProvider.CODEC.fieldOf("wall_provider").withDefault(new SimpleBlockStateProvider(Blocks.STONE_BRICKS.getDefaultState())).forGetter(config -> config.wallProvider),
                 BlockStateProvider.CODEC.fieldOf("floor_provider").withDefault(new SimpleBlockStateProvider(Blocks.SNOW_BLOCK.getDefaultState())).forGetter(config -> config.floorProvider),
+                BlockStateProvider.CODEC.fieldOf("lava_provider").withDefault(new SimpleBlockStateProvider(Blocks.LAVA.getDefaultState())).forGetter(config -> config.lavaProvider),
                 MapShape.REGISTRY_CODEC.fieldOf("shape").forGetter(config -> config.shape)
         ).apply(instance, SpleefMapConfig::new);
     });
@@ -23,13 +24,15 @@ public final class SpleefMapConfig {
     public final int levelHeight;
     public final BlockStateProvider wallProvider;
     public final BlockStateProvider floorProvider;
+    public final BlockStateProvider lavaProvider;
     public final MapShape shape;
 
-    public SpleefMapConfig(int levels, int levelHeight, BlockStateProvider wallProvider, BlockStateProvider floorProvider, MapShape shape) {
+    public SpleefMapConfig(int levels, int levelHeight, BlockStateProvider wallProvider, BlockStateProvider floorProvider, BlockStateProvider lavaProvider, MapShape shape) {
         this.levels = levels;
         this.levelHeight = levelHeight;
         this.wallProvider = wallProvider;
         this.floorProvider = floorProvider;
+        this.lavaProvider = lavaProvider;
 		this.shape = shape;
     }
 }

--- a/src/main/java/net/gegy1000/spleef/game/map/SpleefMapConfig.java
+++ b/src/main/java/net/gegy1000/spleef/game/map/SpleefMapConfig.java
@@ -4,31 +4,32 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 import net.gegy1000.spleef.game.map.shape.MapShape;
-import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
+import net.minecraft.world.gen.stateprovider.BlockStateProvider;
+import net.minecraft.world.gen.stateprovider.SimpleBlockStateProvider;
 
 public final class SpleefMapConfig {
     public static final Codec<SpleefMapConfig> CODEC = RecordCodecBuilder.create(instance -> {
         return instance.group(
                 Codec.INT.fieldOf("levels").forGetter(config -> config.levels),
                 Codec.INT.fieldOf("level_height").forGetter(map -> map.levelHeight),
-                BlockState.CODEC.optionalFieldOf("wall", Blocks.STONE_BRICKS.getDefaultState()).forGetter(config -> config.wall),
-                BlockState.CODEC.optionalFieldOf("floor", Blocks.SNOW_BLOCK.getDefaultState()).forGetter(config -> config.floor),
+                BlockStateProvider.CODEC.fieldOf("wall_provider").withDefault(new SimpleBlockStateProvider(Blocks.STONE_BRICKS.getDefaultState())).forGetter(config -> config.wallProvider),
+                BlockStateProvider.CODEC.fieldOf("floor_provider").withDefault(new SimpleBlockStateProvider(Blocks.SNOW_BLOCK.getDefaultState())).forGetter(config -> config.floorProvider),
                 MapShape.REGISTRY_CODEC.fieldOf("shape").forGetter(config -> config.shape)
         ).apply(instance, SpleefMapConfig::new);
     });
 
     public final int levels;
     public final int levelHeight;
-    public final BlockState wall;
-    public final BlockState floor;
+    public final BlockStateProvider wallProvider;
+    public final BlockStateProvider floorProvider;
     public final MapShape shape;
 
-    public SpleefMapConfig(int levels, int levelHeight, BlockState wall, BlockState floor, MapShape shape) {
+    public SpleefMapConfig(int levels, int levelHeight, BlockStateProvider wallProvider, BlockStateProvider floorProvider, MapShape shape) {
         this.levels = levels;
         this.levelHeight = levelHeight;
-        this.wall = wall;
-        this.floor = floor;
-        this.shape = shape;
+        this.wallProvider = wallProvider;
+        this.floorProvider = floorProvider;
+		this.shape = shape;
     }
 }

--- a/src/main/java/net/gegy1000/spleef/game/map/SpleefMapGenerator.java
+++ b/src/main/java/net/gegy1000/spleef/game/map/SpleefMapGenerator.java
@@ -7,11 +7,9 @@ import java.util.concurrent.CompletableFuture;
 
 import net.gegy1000.plasmid.game.map.template.MapTemplate;
 import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
 import net.minecraft.util.Util;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.gen.stateprovider.BlockStateProvider;
-import net.minecraft.world.gen.stateprovider.SimpleBlockStateProvider;
 
 public final class SpleefMapGenerator {
     private final SpleefMapConfig config;
@@ -44,7 +42,7 @@ public final class SpleefMapGenerator {
 
     private void addBase(MapTemplate template, Random random) {
         BlockStateProvider wallProvider = this.config.wallProvider;
-        BlockStateProvider lavaProvider = new SimpleBlockStateProvider(Blocks.LAVA.getDefaultState());
+        BlockStateProvider lavaProvider = this.config.lavaProvider;
 
         this.config.shape.generate(template, 0, 0, Brush.fill(wallProvider), random);
         this.config.shape.generate(template, 1, 1, new Brush(wallProvider, lavaProvider), random);

--- a/src/main/java/net/gegy1000/spleef/game/map/shape/CircleShape.java
+++ b/src/main/java/net/gegy1000/spleef/game/map/shape/CircleShape.java
@@ -1,12 +1,13 @@
 package net.gegy1000.spleef.game.map.shape;
 
+import java.util.Random;
+
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 import net.gegy1000.plasmid.game.map.template.MapTemplate;
 import net.gegy1000.plasmid.util.BlockBounds;
 import net.gegy1000.spleef.game.map.SpleefMapGenerator.Brush;
-import net.minecraft.block.BlockState;
 import net.minecraft.util.math.BlockPos;
 
 public class CircleShape implements MapShape {
@@ -26,16 +27,13 @@ public class CircleShape implements MapShape {
     }
 
     @Override
-    public void generate(MapTemplate template, int minY, int maxY, Brush brush) {
+    public void generate(MapTemplate template, int minY, int maxY, Brush brush, Random random) {
         BlockPos.Mutable mutablePos = new BlockPos.Mutable();
 
         int radius2 = this.radius * this.radius;
         int outlineRadius2 = (this.radius - 1) * (this.radius - 1);
         int innerRadius2 = (this.innerRadius - 1) * (this.innerRadius - 1);
         int inlineRadius2 = this.innerRadius * this.innerRadius;
-
-        BlockState outline = brush.outline;
-        BlockState fill = brush.fill;
 
         for (int z = -this.radius; z <= this.radius; z++) {
             for (int x = -this.radius; x <= this.radius; x++) {
@@ -46,15 +44,15 @@ public class CircleShape implements MapShape {
 
                 mutablePos.set(x, 0, z);
 
-                if ((distance2 >= outlineRadius2 || (distance2 < inlineRadius2 && this.innerRadius > 0)) && outline != null) {
+                if ((distance2 >= outlineRadius2 || (distance2 < inlineRadius2 && this.innerRadius > 0)) && brush.outlineProvider != null) {
                     for (int y = minY; y <= maxY; y++) {
                         mutablePos.setY(y);
-                        template.setBlockState(mutablePos, outline);
+                        template.setBlockState(mutablePos, brush.provideOutline(random, mutablePos));
                     }
-                } else if (fill != null) {
+                } else if (brush.fillProvider != null) {
                     for (int y = minY; y <= maxY; y++) {
                         mutablePos.setY(y);
-                        template.setBlockState(mutablePos, fill);
+                        template.setBlockState(mutablePos, brush.provideFill(random, mutablePos));
                     }
                 }
             }

--- a/src/main/java/net/gegy1000/spleef/game/map/shape/MapShape.java
+++ b/src/main/java/net/gegy1000/spleef/game/map/shape/MapShape.java
@@ -1,5 +1,6 @@
 package net.gegy1000.spleef.game.map.shape;
 
+import java.util.Random;
 import java.util.function.Function;
 
 import com.mojang.serialization.Codec;
@@ -14,7 +15,7 @@ public interface MapShape {
     public static final TinyRegistry<Codec<? extends MapShape>> REGISTRY = TinyRegistry.newStable();
     public static final MapCodec<MapShape> REGISTRY_CODEC = REGISTRY.dispatchMap(MapShape::getCodec, Function.identity());
 
-    public void generate(MapTemplate template, int minY, int maxY, Brush brush);
+    public void generate(MapTemplate template, int minY, int maxY, Brush brush, Random random);
     public BlockBounds getLevelBounds(int y);
 
     public default int getSpawnOffset() {

--- a/src/main/java/net/gegy1000/spleef/game/map/shape/SquareShape.java
+++ b/src/main/java/net/gegy1000/spleef/game/map/shape/SquareShape.java
@@ -1,12 +1,13 @@
 package net.gegy1000.spleef.game.map.shape;
 
+import java.util.Random;
+
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 import net.gegy1000.plasmid.game.map.template.MapTemplate;
 import net.gegy1000.plasmid.util.BlockBounds;
 import net.gegy1000.spleef.game.map.SpleefMapGenerator.Brush;
-import net.minecraft.block.BlockState;
 import net.minecraft.util.math.BlockPos;
 
 public class SquareShape implements MapShape {
@@ -23,25 +24,22 @@ public class SquareShape implements MapShape {
     }
 
     @Override
-    public void generate(MapTemplate template, int minY, int maxY, Brush brush) {
+    public void generate(MapTemplate template, int minY, int maxY, Brush brush, Random random) {
         BlockPos.Mutable mutablePos = new BlockPos.Mutable();
-
-        BlockState outline = brush.outline;
-        BlockState fill = brush.fill;
 
         for (int z = -this.size; z <= this.size; z++) {
             for (int x = -this.size; x <= this.size; x++) {
                 mutablePos.set(x, 0, z);
 
-                if ((z == -this.size || z == this.size || x == -this.size || x == this.size) && outline != null) {
+                if ((z == -this.size || z == this.size || x == -this.size || x == this.size) && brush.outlineProvider != null) {
                     for (int y = minY; y <= maxY; y++) {
                         mutablePos.setY(y);
-                        template.setBlockState(mutablePos, outline);
+                        template.setBlockState(mutablePos, brush.provideOutline(random, mutablePos));
                     }
-                } else if (fill != null) {
+                } else if (brush.fillProvider != null) {
                     for (int y = minY; y <= maxY; y++) {
                         mutablePos.setY(y);
-                        template.setBlockState(mutablePos, fill);
+                        template.setBlockState(mutablePos, brush.provideFill(random, mutablePos));
                     }
                 }
             }


### PR DESCRIPTION
This pull request replaces the `wall` and `floor` fields in the map configuration with `wall_provider` and `floor_provider`. These fields are more advanced as they use the vanilla block state provider system, allowing for more complex patterns such as a weighted selection of block states.