### PR TITLE
Add ceilings

### DIFF
--- a/src/main/java/xyz/nucleoid/spleef/game/map/SpleefMapConfig.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/map/SpleefMapConfig.java
@@ -15,6 +15,7 @@ public final class SpleefMapConfig {
                 Codec.INT.fieldOf("level_height").forGetter(map -> map.levelHeight),
                 BlockStateProvider.CODEC.optionalFieldOf("wall_provider", new SimpleBlockStateProvider(Blocks.STONE_BRICKS.getDefaultState())).forGetter(config -> config.wallProvider),
                 BlockStateProvider.CODEC.optionalFieldOf("floor_provider", new SimpleBlockStateProvider(Blocks.SNOW_BLOCK.getDefaultState())).forGetter(config -> config.floorProvider),
+                BlockStateProvider.CODEC.optionalFieldOf("ceiling_provider", new SimpleBlockStateProvider(Blocks.BARRIER.getDefaultState())).forGetter(config -> config.ceilingProvider),
                 BlockStateProvider.CODEC.optionalFieldOf("lava_provider", new SimpleBlockStateProvider(Blocks.LAVA.getDefaultState())).forGetter(config -> config.lavaProvider),
                 MapShape.REGISTRY_CODEC.fieldOf("shape").forGetter(config -> config.shape)
         ).apply(instance, SpleefMapConfig::new);
@@ -24,14 +25,16 @@ public final class SpleefMapConfig {
     public final int levelHeight;
     public final BlockStateProvider wallProvider;
     public final BlockStateProvider floorProvider;
+    public final BlockStateProvider ceilingProvider;
     public final BlockStateProvider lavaProvider;
     public final MapShape shape;
 
-    public SpleefMapConfig(int levels, int levelHeight, BlockStateProvider wallProvider, BlockStateProvider floorProvider, BlockStateProvider lavaProvider, MapShape shape) {
+    public SpleefMapConfig(int levels, int levelHeight, BlockStateProvider wallProvider, BlockStateProvider floorProvider, BlockStateProvider ceilingProvider, BlockStateProvider lavaProvider, MapShape shape) {
         this.levels = levels;
         this.levelHeight = levelHeight;
         this.wallProvider = wallProvider;
         this.floorProvider = floorProvider;
+        this.ceilingProvider = ceilingProvider;
         this.lavaProvider = lavaProvider;
 		this.shape = shape;
     }

--- a/src/main/java/xyz/nucleoid/spleef/game/map/SpleefMapGenerator.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/map/SpleefMapGenerator.java
@@ -32,7 +32,7 @@ public final class SpleefMapGenerator {
 
         this.addBase(template, random);
         this.addLevels(template, map, providedFloors, random);
-        this.addWall(template, random);
+        this.addWallAndCeiling(template, random);
 
         int offset = this.config.shape.getSpawnOffset();
         map.setSpawn(new BlockPos(offset, this.config.levels * this.config.levelHeight + 2, 0));
@@ -59,13 +59,16 @@ public final class SpleefMapGenerator {
         }
     }
 
-    private void addWall(MapTemplate template, Random random) {
+    private void addWallAndCeiling(MapTemplate template, Random random) {
         Brush wallBrush = Brush.outline(this.config.wallProvider);
 
         int minY = 1;
         int maxY = (this.config.levels + 1) * this.config.levelHeight;
 
         this.config.shape.generate(template, minY, maxY, wallBrush, random);
+
+        Brush ceilingBrush = Brush.fill(this.config.ceilingProvider);
+        this.config.shape.generate(template, maxY + 1, maxY + 1, ceilingBrush, random);
     }
 
     public static final class Brush {


### PR DESCRIPTION
This pull request adds a ceiling to the generated spleef map. By default, this ceiling is made entirely out of barriers, but a custom block state provider can be provided in the map configuration as `ceiling_provider`.