### PR TITLE
Add warning when lava rises

### DIFF
--- a/src/main/java/xyz/nucleoid/spleef/game/SpleefActive.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/SpleefActive.java
@@ -127,6 +127,8 @@ public final class SpleefActive {
             }
 
             this.nextLevelDropTime = time + this.config.levelBreakInterval();
+        } else if(map.getTopLevel() <= -1 & lavaRise != null) {
+            timerBar.setBarLava();
         } else {
             long ticksToDrop = this.nextLevelDropTime - time;
             if (ticksToDrop % 20 == 0) {

--- a/src/main/java/xyz/nucleoid/spleef/game/SpleefTimerBar.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/SpleefTimerBar.java
@@ -27,6 +27,14 @@ public final class SpleefTimerBar {
         }
     }
 
+    public void setBarLava(){
+        var gameName = new TranslatableText("game.spleef.spleef").formatted(Formatting.BOLD);
+        var lavaMsg = new TranslatableText("game.spleef.lava.msg");
+        this.widget.setTitle(new LiteralText("").append(gameName).append(" - ").append(lavaMsg).formatted(Formatting.RED));
+        this.widget.setStyle(BossBar.Color.RED, BossBar.Style.NOTCHED_10);
+        this.widget.setProgress(1f);
+    }
+
     private Text getDroppingText(long ticksUntilDrop) {
         long secondsUntilDrop = ticksUntilDrop / 20;
 

--- a/src/main/java/xyz/nucleoid/spleef/game/map/SpleefMap.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/map/SpleefMap.java
@@ -176,6 +176,10 @@ public final class SpleefMap {
         return this.spawn;
     }
 
+    public int getTopLevel() {
+        return topLevel;
+    }
+
     public ChunkGenerator asGenerator(MinecraftServer server) {
         return new TemplateChunkGenerator(server, this.template);
     }

--- a/src/main/resources/data/spleef/lang/en_us.json
+++ b/src/main/resources/data/spleef/lang/en_us.json
@@ -4,5 +4,6 @@
   "game.spleef.projectiles": "Spleef with Projectiles",
   "game.spleef.decay": "Spleef with Decay",
 
-  "game.spleef.standard.desc": "In spleef, you must break the blocks beneath players to make them fall!"
+  "game.spleef.standard.desc": "In spleef, you must break the blocks beneath players to make them fall!",
+  "game.spleef.lava.msg": "Lava is now rising!"
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/68478692/128193073-793a1e61-1fdf-4b06-8e94-c547848bfe43.png)
Now when the last layer of the map drops and lava is set to rise in the config the boss bar now displays a warning that the lava is rising. This fixes an issue in games such as explosive tater spleef (alt) where players build up after the last layer is gone the boss bar would still count down. With the change I made the boss bar changes as seen in the above screenshot after this point unless if lava doesn't rise. This was done for normal spleef games when the last layer drops the remaining players in as the message about lava rising would display as soon as that layer was gone other wise. Meaning it would be shown right before the remaining players die instead of the normal boss bar being on cool down. The message is also translatable with the lang file.