### PR TITLE
Prevent players from being eliminated after the game is stopped

### DIFF
--- a/src/main/java/xyz/nucleoid/spleef/game/SpleefActive.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/SpleefActive.java
@@ -228,7 +228,7 @@ public final class SpleefActive {
     }
 
     private ActionResult onPlayerDamage(ServerPlayerEntity player, DamageSource source, float amount) {
-        if (!player.isSpectator() && source == DamageSource.LAVA) {
+        if (!player.isSpectator() && source == DamageSource.LAVA && !result.win()) {
             this.eliminatePlayer(player);
         }
         return ActionResult.FAIL;


### PR DESCRIPTION
Tell me if I'm wrong. This should only eliminate a player if nobody has won yet.

Fixes #25