### PR TITLE
Fix lava bossbar translations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,8 @@ repositories {
 	maven { url = "https://maven.gegy.dev/" }
 }
 
-minecraft {
-	accessWidener = file("src/main/resources/spleef.accesswidener")
+loom {
+	accessWidenerPath = file("src/main/resources/spleef.accesswidener")
 }
 
 dependencies {
@@ -28,7 +28,7 @@ dependencies {
 
 	modImplementation 'xyz.nucleoid:plasmid:0.5.40+1.18'
 
-	modRuntime ("supercoder79:databreaker:0.2.8") {
+	modRuntimeOnly ("supercoder79:databreaker:0.2.8") {
 		exclude module : "fabric-loader"
 	}
 }
@@ -43,7 +43,7 @@ processResources {
 
 tasks.withType(JavaCompile).configureEach {
 	it.options.encoding = "UTF-8"
-	it.options.release = 16
+	it.options.release = 17
 }
 
 java {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,5 @@
 pluginManagement {
     repositories {
-        mavenCentral()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'

--- a/src/main/java/xyz/nucleoid/spleef/game/SpleefTimerBar.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/SpleefTimerBar.java
@@ -43,7 +43,7 @@ public final class SpleefTimerBar {
         return getBarTitle(new TranslatableText("text.spleef.bar.dropping", time), Formatting.GREEN);
     }
 
-    private static Text getBarTitle(Text customText, Formatting color ) {
+    private static Text getBarTitle(Text customText, Formatting color) {
         var gameName = new TranslatableText("gameType.spleef.spleef").formatted(Formatting.BOLD);
         return new LiteralText("").append(gameName).append(" - ").append(customText).formatted(color);
     }

--- a/src/main/java/xyz/nucleoid/spleef/game/SpleefTimerBar.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/SpleefTimerBar.java
@@ -16,7 +16,7 @@ public final class SpleefTimerBar {
     }
 
     static SpleefTimerBar create(GlobalWidgets widgets) {
-        var title = getBarTitle(new TranslatableText("text.spleef.bar.dropping.none"), "GREEN");
+        var title = getBarTitle(new TranslatableText("text.spleef.bar.dropping.none"), Formatting.GREEN);
         return new SpleefTimerBar(widgets.addBossBar(title, BossBar.Color.GREEN, BossBar.Style.NOTCHED_10));
     }
 
@@ -28,7 +28,7 @@ public final class SpleefTimerBar {
     }
 
     public void setBarLava(){
-        this.widget.setTitle(getBarTitle(new TranslatableText("game.spleef.lava.msg"), "RED"));
+        this.widget.setTitle(getBarTitle(new TranslatableText("game.spleef.lava.msg"), Formatting.RED));
         this.widget.setStyle(BossBar.Color.RED, BossBar.Style.NOTCHED_10);
         this.widget.setProgress(1f);
     }
@@ -40,11 +40,11 @@ public final class SpleefTimerBar {
         long seconds = secondsUntilDrop % 60;
         var time = String.format("%02d:%02d", minutes, seconds);
 
-        return getBarTitle(new TranslatableText("text.spleef.bar.dropping", time), "GREEN");
+        return getBarTitle(new TranslatableText("text.spleef.bar.dropping", time), Formatting.GREEN);
     }
 
-    private static Text getBarTitle(Text customText, String color ) {
+    private static Text getBarTitle(Text customText, Formatting color ) {
         var gameName = new TranslatableText("gameType.spleef.spleef").formatted(Formatting.BOLD);
-        return new LiteralText("").append(gameName).append(" - ").append(customText).formatted(Formatting.valueOf(color));
+        return new LiteralText("").append(gameName).append(" - ").append(customText).formatted(color);
     }
 }

--- a/src/main/java/xyz/nucleoid/spleef/game/SpleefTimerBar.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/SpleefTimerBar.java
@@ -16,7 +16,7 @@ public final class SpleefTimerBar {
     }
 
     static SpleefTimerBar create(GlobalWidgets widgets) {
-        var title = getBarTitle(new TranslatableText("text.spleef.bar.dropping.none"));
+        var title = getBarTitle(new TranslatableText("text.spleef.bar.dropping.none"), "GREEN");
         return new SpleefTimerBar(widgets.addBossBar(title, BossBar.Color.GREEN, BossBar.Style.NOTCHED_10));
     }
 
@@ -28,9 +28,7 @@ public final class SpleefTimerBar {
     }
 
     public void setBarLava(){
-        var gameName = new TranslatableText("gameType.spleef.spleef").formatted(Formatting.BOLD);
-        var lavaMsg = new TranslatableText("game.spleef.lava.msg");
-        this.widget.setTitle(new LiteralText("").append(gameName).append(" - ").append(lavaMsg).formatted(Formatting.RED));
+        this.widget.setTitle(getBarTitle(new TranslatableText("game.spleef.lava.msg"), "RED"));
         this.widget.setStyle(BossBar.Color.RED, BossBar.Style.NOTCHED_10);
         this.widget.setProgress(1f);
     }
@@ -42,11 +40,11 @@ public final class SpleefTimerBar {
         long seconds = secondsUntilDrop % 60;
         var time = String.format("%02d:%02d", minutes, seconds);
 
-        return getBarTitle(new TranslatableText("text.spleef.bar.dropping", time));
+        return getBarTitle(new TranslatableText("text.spleef.bar.dropping", time), "GREEN");
     }
 
-    private static Text getBarTitle(Text customText) {
+    private static Text getBarTitle(Text customText, String color ) {
         var gameName = new TranslatableText("gameType.spleef.spleef").formatted(Formatting.BOLD);
-        return new LiteralText("").append(gameName).append(" - ").append(customText).formatted(Formatting.GREEN);
+        return new LiteralText("").append(gameName).append(" - ").append(customText).formatted(Formatting.valueOf(color));
     }
 }

--- a/src/main/java/xyz/nucleoid/spleef/game/SpleefTimerBar.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/SpleefTimerBar.java
@@ -28,7 +28,7 @@ public final class SpleefTimerBar {
     }
 
     public void setBarLava(){
-        var gameName = new TranslatableText("game.spleef.spleef").formatted(Formatting.BOLD);
+        var gameName = new TranslatableText("gameType.spleef.spleef").formatted(Formatting.BOLD);
         var lavaMsg = new TranslatableText("game.spleef.lava.msg");
         this.widget.setTitle(new LiteralText("").append(gameName).append(" - ").append(lavaMsg).formatted(Formatting.RED));
         this.widget.setStyle(BossBar.Color.RED, BossBar.Style.NOTCHED_10);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -12,7 +12,7 @@
   },
   "accessWidener": "spleef.accesswidener",
   "depends": {
-    "fabricloader": ">=0.9.1",
+    "fabricloader": ">=0.12.12",
     "fabric": "*",
     "minecraft": "1.18.x",
     "plasmid": "0.5.x",


### PR DESCRIPTION
This pull request fixes an oversight in https://github.com/NucleoidMC/spleef/pull/35 where a translation was missed causing it to display the translation string in game instead of the translated text. There are also a few build system changes that will be listed below. These were done to prevent depreciation warnings and make sure the mod still compiles once jcenter goes down. There is one small changed that needs to be made to one commit if it is back ported to 1.17.

**Build System Changes**
- updated `accessWidener` to use loom's new `accessWidenerPath` (deprecated soon)
- updated `modRuntime` to `modRuntimeOnly` (deprecated soon)
- changed `it.options.release` to Java 17 (conflicts with 1.17)
- Updated Gradle to 7.3.3
- Remove `jcenter` 
- Updated `fabric-loader` requirement in the `fabric.mod.json` to the most recent version

To make a562019f23e993114b62475daf8fb1cbbd1828ae compatible with 1.17 you will we need to merge it acknowledging that the build compatibility level will be changed to Java 17 or make a follow up commit changing `it.options.release` back to Java 16. I also originally changed jcenter out for mavenCentral but removed it as it's unused. If you ever need to use it in the future put `mavenCentral()` in the build.gradle. 