### PR TITLE
Add configuration for the number of tool recipients

### DIFF
--- a/src/main/java/xyz/nucleoid/spleef/game/SpleefConfig.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/SpleefConfig.java
@@ -2,8 +2,6 @@ package xyz.nucleoid.spleef.game;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
 import org.jetbrains.annotations.Nullable;
 import xyz.nucleoid.plasmid.game.common.config.PlayerConfig;
 import xyz.nucleoid.spleef.game.map.SpleefMapConfig;
@@ -13,7 +11,7 @@ import java.util.Optional;
 public final record SpleefConfig(
         SpleefMapConfig map,
         PlayerConfig players,
-        ItemStack tool,
+        ToolConfig tool,
         @Nullable ProjectileConfig projectile,
         @Nullable LavaRiseConfig lavaRise,
         long levelBreakInterval,
@@ -25,7 +23,7 @@ public final record SpleefConfig(
         return instance.group(
                 SpleefMapConfig.CODEC.fieldOf("map").forGetter(SpleefConfig::map),
                 PlayerConfig.CODEC.fieldOf("players").forGetter(SpleefConfig::players),
-                ItemStack.CODEC.optionalFieldOf("tool", new ItemStack(Items.DIAMOND_SHOVEL)).forGetter(SpleefConfig::tool),
+                ToolConfig.CODEC.optionalFieldOf("tool", ToolConfig.DEFAULT).forGetter(SpleefConfig::tool),
                 ProjectileConfig.CODEC.optionalFieldOf("projectile").forGetter(config -> Optional.ofNullable(config.projectile())),
                 LavaRiseConfig.CODEC.optionalFieldOf("lava_rise").forGetter(config -> Optional.ofNullable(config.lavaRise())),
                 Codec.LONG.optionalFieldOf("level_break_interval", 20L * 60).forGetter(SpleefConfig::levelBreakInterval),
@@ -38,7 +36,7 @@ public final record SpleefConfig(
     private SpleefConfig(
             SpleefMapConfig map,
             PlayerConfig players,
-            ItemStack tool,
+            ToolConfig tool,
             Optional<ProjectileConfig> projectile,
             Optional<LavaRiseConfig> lavaRise,
             long levelBreakInterval,

--- a/src/main/java/xyz/nucleoid/spleef/game/ToolConfig.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/ToolConfig.java
@@ -1,0 +1,49 @@
+package xyz.nucleoid.spleef.game;
+
+import java.util.function.Function;
+
+import com.mojang.datafixers.util.Either;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import net.minecraft.enchantment.Enchantments;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import xyz.nucleoid.plasmid.util.ItemStackBuilder;
+import xyz.nucleoid.spleef.game.map.SpleefMap;
+
+public record ToolConfig(ItemStack stack, int recipients) {
+    private static final ItemStack DEFAULT_STACK = new ItemStack(Items.DIAMOND_SHOVEL);
+    private static final int DEFAULT_RECIPIENTS = -1;
+
+    public static final ToolConfig DEFAULT = new ToolConfig(DEFAULT_STACK, DEFAULT_RECIPIENTS);
+
+    private static final Codec<ToolConfig> RECORD_CODEC = RecordCodecBuilder.create(instance -> {
+        return instance.group(
+                ItemStack.CODEC.optionalFieldOf("stack", DEFAULT_STACK).forGetter(ToolConfig::stack),
+                Codec.INT.optionalFieldOf("recipients", DEFAULT_RECIPIENTS).forGetter(ToolConfig::recipients)
+        ).apply(instance, ToolConfig::new);
+    });
+
+    public static final Codec<ToolConfig> CODEC = Codec.either(ItemStack.CODEC, RECORD_CODEC).xmap(either -> {
+        return either.map(stack -> {
+            return new ToolConfig(stack, DEFAULT_RECIPIENTS);
+        }, Function.identity());
+    }, Either::right);
+
+    public ItemStack createStack(int index, SpleefMap map) {
+        if (this.recipients > DEFAULT_RECIPIENTS && index >= this.recipients) {
+            return ItemStack.EMPTY;
+        }
+
+        var shovelBuilder = ItemStackBuilder.of(this.stack())
+                .setUnbreakable()
+                .addEnchantment(Enchantments.EFFICIENCY, 2);
+
+        for (var state : map.providedFloors) {
+            shovelBuilder.addCanDestroy(state.getBlock());
+        }
+
+        return shovelBuilder.build();
+    }
+}


### PR DESCRIPTION
This pull request expands tool configuration to include a number of recipients. This value can be specified with a full tool configuration:

```json
{
	"tool": {
		"stack": {
			"id": "minecraft:iron_shovel",
			"Count": 1
		},
		"recipients": 3
	}
}
```

The default and existing tool configurations default to a value of `-1`, meaning every player will get the tool.