### PR TITLE
Add block break actions

### DIFF
--- a/src/main/java/xyz/nucleoid/spleef/Spleef.java
+++ b/src/main/java/xyz/nucleoid/spleef/Spleef.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.Logger;
 import xyz.nucleoid.plasmid.game.GameType;
 import xyz.nucleoid.spleef.game.SpleefConfig;
 import xyz.nucleoid.spleef.game.SpleefWaiting;
+import xyz.nucleoid.spleef.game.action.*;
 import xyz.nucleoid.spleef.game.map.shape.renderer.*;
 
 public final class Spleef implements ModInitializer {
@@ -31,5 +32,11 @@ public final class Spleef implements ModInitializer {
         MapShapeRenderer.REGISTRY.register(new Identifier(Spleef.ID, "square"), SquareShapeRenderer.CODEC);
         MapShapeRenderer.REGISTRY.register(new Identifier(Spleef.ID, "sierpinski_carpet"), SierpinskiCarpetShapeRenderer.CODEC);
         MapShapeRenderer.REGISTRY.register(new Identifier(Spleef.ID, "pattern"), PatternShapeRenderer.CODEC);
+
+        BlockAction.REGISTRY.register(new Identifier(Spleef.ID, "add_status_effect"), AddStatusEffectBlockAction.CODEC);
+        BlockAction.REGISTRY.register(new Identifier(Spleef.ID, "give_item_stack"), GiveItemStackBlockAction.CODEC);
+        BlockAction.REGISTRY.register(new Identifier(Spleef.ID, "restock_projectile"), RestockProjectileBlockAction.CODEC);
+        BlockAction.REGISTRY.register(new Identifier(Spleef.ID, "send_message"), SendMessageBlockAction.CODEC);
+        BlockAction.REGISTRY.register(new Identifier(Spleef.ID, "sequence"), SequenceBlockAction.CODEC);
     }
 }

--- a/src/main/java/xyz/nucleoid/spleef/game/SpleefConfig.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/SpleefConfig.java
@@ -3,12 +3,17 @@ package xyz.nucleoid.spleef.game;
 import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.block.Block;
+import net.minecraft.registry.Registries;
 import net.minecraft.util.dynamic.Codecs;
 import org.jetbrains.annotations.Nullable;
 import xyz.nucleoid.plasmid.game.common.config.PlayerConfig;
+import xyz.nucleoid.spleef.game.action.BlockAction;
 import xyz.nucleoid.spleef.game.map.SpleefGeneratedMapConfig;
 import xyz.nucleoid.spleef.game.map.SpleefTemplateMapConfig;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
 public record SpleefConfig(
@@ -17,6 +22,7 @@ public record SpleefConfig(
         ToolConfig tool,
         @Nullable ProjectileConfig projectile,
         @Nullable LavaRiseConfig lavaRise,
+        Map<Block, BlockAction> blockBreakActions,
         long levelBreakInterval,
         int decay,
         int timeOfDay,
@@ -28,6 +34,7 @@ public record SpleefConfig(
         ToolConfig.CODEC.optionalFieldOf("tool", ToolConfig.DEFAULT).forGetter(SpleefConfig::tool),
         ProjectileConfig.CODEC.optionalFieldOf("projectile").forGetter(config -> Optional.ofNullable(config.projectile())),
         LavaRiseConfig.CODEC.optionalFieldOf("lava_rise").forGetter(config -> Optional.ofNullable(config.lavaRise())),
+        Codec.unboundedMap(Registries.BLOCK.getCodec(), BlockAction.REGISTRY_CODEC).optionalFieldOf("block_break_actions", Collections.emptyMap()).forGetter(SpleefConfig::blockBreakActions),
         Codec.LONG.optionalFieldOf("level_break_interval", 20L * 60).forGetter(SpleefConfig::levelBreakInterval),
         Codec.INT.optionalFieldOf("decay", -1).forGetter(SpleefConfig::decay),
         Codec.INT.optionalFieldOf("time_of_day", 6000).forGetter(SpleefConfig::timeOfDay),
@@ -40,6 +47,7 @@ public record SpleefConfig(
             ToolConfig tool,
             Optional<ProjectileConfig> projectile,
             Optional<LavaRiseConfig> lavaRise,
+            Map<Block, BlockAction> blockBreakActions,
             long levelBreakInterval,
             int decay,
             int timeOfDay,
@@ -49,6 +57,7 @@ public record SpleefConfig(
                 map, players, tool,
                 projectile.orElse(null),
                 lavaRise.orElse(null),
+                blockBreakActions,
                 levelBreakInterval, decay,
                 timeOfDay,
                 unstableTnt

--- a/src/main/java/xyz/nucleoid/spleef/game/action/AddStatusEffectBlockAction.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/action/AddStatusEffectBlockAction.java
@@ -1,0 +1,42 @@
+package xyz.nucleoid.spleef.game.action;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.entity.effect.StatusEffectInstance;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.server.network.ServerPlayerEntity;
+import xyz.nucleoid.codecs.MoreCodecs;
+
+public record AddStatusEffectBlockAction(StatusEffectInstance effect, BlockActionTarget target) implements BlockAction {
+    private static final Codec<StatusEffectInstance> STATUS_EFFECT_CODEC = MoreCodecs.withNbt(effect -> effect.writeNbt(new NbtCompound()), nbt -> {
+        if (nbt instanceof NbtCompound compound) {
+            var effect = StatusEffectInstance.fromNbt(compound);
+
+            if (effect == null) {
+                return DataResult.error(() -> "Unknown status effect ID");
+            } else {
+                return DataResult.success(effect);
+            }
+        }
+
+        return DataResult.error(() -> "Expected compound tag");
+    });
+
+    public static final Codec<AddStatusEffectBlockAction> CODEC = RecordCodecBuilder.create(instance -> {
+        return instance.group(
+                STATUS_EFFECT_CODEC.fieldOf("effect").forGetter(AddStatusEffectBlockAction::effect),
+                BlockActionTarget.CODEC.fieldOf("target").forGetter(AddStatusEffectBlockAction::target)
+        ).apply(instance, AddStatusEffectBlockAction::new);
+    });
+
+    @Override
+    public void apply(ServerPlayerEntity player, BlockActionContext context) {
+        player.addStatusEffect(new StatusEffectInstance(this.effect), player);
+    }
+
+    @Override
+    public Codec<AddStatusEffectBlockAction> getCodec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/xyz/nucleoid/spleef/game/action/BlockAction.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/action/BlockAction.java
@@ -1,0 +1,28 @@
+package xyz.nucleoid.spleef.game.action;
+
+import com.mojang.serialization.Codec;
+import net.minecraft.server.network.ServerPlayerEntity;
+import xyz.nucleoid.plasmid.game.player.PlayerSet;
+import xyz.nucleoid.plasmid.registry.TinyRegistry;
+import xyz.nucleoid.spleef.game.SpleefActive;
+
+import java.util.function.Function;
+
+public interface BlockAction {
+    TinyRegistry<Codec<? extends BlockAction>> REGISTRY = TinyRegistry.create();
+    Codec<BlockAction> REGISTRY_CODEC = REGISTRY.dispatchMap(BlockAction::getCodec, Function.identity()).codec();
+
+    public void apply(ServerPlayerEntity player, BlockActionContext context);
+
+    public BlockActionTarget target();
+
+    Codec<? extends BlockAction> getCodec();
+
+    public static void apply(BlockAction action, ServerPlayerEntity self, PlayerSet players, SpleefActive game) {
+        var context = new BlockActionContext(self, players, game);
+
+        action.target().forEachTarget(context, player -> {
+            action.apply(player, context);
+        });
+    }
+}

--- a/src/main/java/xyz/nucleoid/spleef/game/action/BlockActionContext.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/action/BlockActionContext.java
@@ -1,0 +1,7 @@
+package xyz.nucleoid.spleef.game.action;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+import xyz.nucleoid.plasmid.game.player.PlayerSet;
+import xyz.nucleoid.spleef.game.SpleefActive;
+
+public record BlockActionContext(ServerPlayerEntity self, PlayerSet players, SpleefActive game) {}

--- a/src/main/java/xyz/nucleoid/spleef/game/action/BlockActionTarget.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/action/BlockActionTarget.java
@@ -1,0 +1,42 @@
+package xyz.nucleoid.spleef.game.action;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.StringIdentifiable;
+
+import java.util.function.Consumer;
+
+public enum BlockActionTarget implements StringIdentifiable {
+    SELF("self"),
+    OTHERS("others"),
+    ALL("all")
+    ;
+
+    public static final com.mojang.serialization.Codec<BlockActionTarget> CODEC = StringIdentifiable.createCodec(BlockActionTarget::values);
+
+    public final String name;
+
+    BlockActionTarget(String name) {
+        this.name = name;
+    }
+
+    public void forEachTarget(BlockActionContext context, Consumer<ServerPlayerEntity> consumer) {
+        if (this == SELF) {
+            consumer.accept(context.self());
+            return;
+        }
+
+        context.players().stream()
+                .filter(player -> {
+                    if (this == OTHERS && player == context.self()) {
+                        return false;
+                    }
+
+                    return !player.isSpectator();
+                })
+                .forEach(consumer);
+    }
+
+    public String asString() {
+        return this.name;
+    }
+}

--- a/src/main/java/xyz/nucleoid/spleef/game/action/GiveItemStackBlockAction.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/action/GiveItemStackBlockAction.java
@@ -1,0 +1,25 @@
+package xyz.nucleoid.spleef.game.action;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+public record GiveItemStackBlockAction(ItemStack stack, BlockActionTarget target) implements BlockAction {
+    public static final Codec<GiveItemStackBlockAction> CODEC = RecordCodecBuilder.create(instance -> {
+        return instance.group(
+                ItemStack.CODEC.fieldOf("stack").forGetter(GiveItemStackBlockAction::stack),
+                BlockActionTarget.CODEC.fieldOf("target").forGetter(GiveItemStackBlockAction::target)
+        ).apply(instance, GiveItemStackBlockAction::new);
+    });
+
+    @Override
+    public void apply(ServerPlayerEntity player, BlockActionContext context) {
+        player.giveItemStack(this.stack.copy());
+    }
+
+    @Override
+    public Codec<GiveItemStackBlockAction> getCodec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/xyz/nucleoid/spleef/game/action/RestockProjectileBlockAction.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/action/RestockProjectileBlockAction.java
@@ -1,0 +1,23 @@
+package xyz.nucleoid.spleef.game.action;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+public record RestockProjectileBlockAction(BlockActionTarget target) implements BlockAction {
+    public static final Codec<RestockProjectileBlockAction> CODEC = RecordCodecBuilder.create(instance -> {
+        return instance.group(
+                BlockActionTarget.CODEC.fieldOf("target").forGetter(RestockProjectileBlockAction::target)
+        ).apply(instance, RestockProjectileBlockAction::new);
+    });
+
+    @Override
+    public void apply(ServerPlayerEntity player, BlockActionContext context) {
+        context.game().restockProjectileFor(player);
+    }
+
+    @Override
+    public Codec<RestockProjectileBlockAction> getCodec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/xyz/nucleoid/spleef/game/action/SendMessageBlockAction.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/action/SendMessageBlockAction.java
@@ -1,0 +1,27 @@
+package xyz.nucleoid.spleef.game.action;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import xyz.nucleoid.plasmid.util.PlasmidCodecs;
+
+public record SendMessageBlockAction(Text message, boolean overlay, BlockActionTarget target) implements BlockAction {
+    public static final Codec<SendMessageBlockAction> CODEC = RecordCodecBuilder.create(instance -> {
+        return instance.group(
+                PlasmidCodecs.TEXT.fieldOf("message").forGetter(SendMessageBlockAction::message),
+                Codec.BOOL.optionalFieldOf("overlay", false).forGetter(SendMessageBlockAction::overlay),
+                BlockActionTarget.CODEC.fieldOf("target").forGetter(SendMessageBlockAction::target)
+        ).apply(instance, SendMessageBlockAction::new);
+    });
+
+    @Override
+    public void apply(ServerPlayerEntity player, BlockActionContext context) {
+        player.sendMessage(this.message, this.overlay);
+    }
+
+    @Override
+    public Codec<SendMessageBlockAction> getCodec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/xyz/nucleoid/spleef/game/action/SequenceBlockAction.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/action/SequenceBlockAction.java
@@ -1,0 +1,33 @@
+package xyz.nucleoid.spleef.game.action;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+import java.util.List;
+
+public record SequenceBlockAction(List<BlockAction> actions) implements BlockAction {
+    public static final Codec<SequenceBlockAction> CODEC = RecordCodecBuilder.create(instance -> {
+        return instance.group(
+                BlockAction.REGISTRY_CODEC.listOf().fieldOf("actions").forGetter(SequenceBlockAction::actions)
+        ).apply(instance, SequenceBlockAction::new);
+    });
+
+    @Override
+    public void apply(ServerPlayerEntity player, BlockActionContext context) {
+        for (var action : this.actions) {
+            action.target().forEachTarget(context, playerx -> {
+                action.apply(player, context);
+            });
+        }
+    }
+
+    public BlockActionTarget target() {
+        return BlockActionTarget.SELF;
+    }
+
+    @Override
+    public Codec<SequenceBlockAction> getCodec() {
+        return CODEC;
+    }
+}


### PR DESCRIPTION
This pull request adds block break actions, which can be used to customize the behavior of breaking blocks. Actions can affect the player that broke the block, all players, or all players except the player that broke the block.

Block break actions can be used to implement additional versions of spleef, such as a version that restocks projectiles when blocks are broken as opposed to on a timer.

For an example of block break action configuration:

```json
{
	"block_break_actions": {
		"minecraft:snow_block": {
			"type": "spleef:sequence",
			"actions": [
				{
					"type": "spleef:add_status_effect",
					"effect": {
						"Id": 1,
						"Duration": 200
					},
					"target": "others"
				},
				{
					"type": "spleef:give_item_stack",
					"stack": {
						"id": "minecraft:tnt",
						"Count": 1
					},
					"target": "all"
				},
				{
					"type": "spleef:restock_projectile",
					"target": "all"
				},
				{
					"type": "spleef:send_message",
					"message": "Example message",
					"overlay": false,
					"target": "self",
				}
			]
		}
	}
}
```

The block action system is extensible and can be extended later to allow configuration in other contexts or additional actions, such as a generic action to run command functions.