### PR TITLE
Avoid adding a duplicate enchantment to the tool stack

### DIFF
--- a/src/main/java/xyz/nucleoid/spleef/game/ToolConfig.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/ToolConfig.java
@@ -6,6 +6,7 @@ import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
+import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.enchantment.Enchantments;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -36,14 +37,18 @@ public record ToolConfig(ItemStack stack, int recipients) {
             return ItemStack.EMPTY;
         }
 
-        var shovelBuilder = ItemStackBuilder.of(this.stack())
-                .setUnbreakable()
-                .addEnchantment(Enchantments.EFFICIENCY, 2);
+        var toolBuilder = ItemStackBuilder.of(this.stack())
+                .setUnbreakable();
 
-        for (var state : map.providedFloors) {
-            shovelBuilder.addCanDestroy(state.getBlock());
+        // Avoid adding a duplicate enchantment
+        if (EnchantmentHelper.getLevel(Enchantments.EFFICIENCY, this.stack()) == 0) {
+            toolBuilder.addEnchantment(Enchantments.EFFICIENCY, 2);
         }
 
-        return shovelBuilder.build();
+        for (var state : map.providedFloors) {
+            toolBuilder.addCanDestroy(state.getBlock());
+        }
+
+        return toolBuilder.build();
     }
 }


### PR DESCRIPTION
This pull request prevents tool stacks from having a duplicate enchantment automatically added if an efficiency enchantment is already specified directly on the tool stack. This change does not affect breaking speed, as the highest efficiency level is already chosen when determining the breaking speed, but makes the tooltip of the tool slightly nicer as only one enchantment will be listed.