### PR TITLE
Fix the name of the Spleef: Snowglobe game not being translated

### DIFF
--- a/src/main/resources/data/spleef/lang/en_us.json
+++ b/src/main/resources/data/spleef/lang/en_us.json
@@ -3,6 +3,7 @@
   "game.spleef.standard": "Spleef",
   "game.spleef.standard_projectiles": "Spleef with Projectiles",
   "game.spleef.standard_decay": "Spleef with Decay",
+  "game.spleef.snowglobe": "Spleef: Snowglobe",
 
   "game.spleef.standard.desc.1": "In spleef, you must break",
   "game.spleef.standard.desc.2": "the blocks beneath players",


### PR DESCRIPTION
<img width="525" alt="Command suggestions showing 'Spleef: Snowglobe' tooltip above 'spleef:snowglobe' suggestion" src="https://github.com/NucleoidMC/spleef/assets/24855774/b27470ed-fa32-4771-b782-78ff62f43129">

Fixes #61