### PR TITLE
Allow configuring attribute modifiers for players

### DIFF
--- a/src/main/java/xyz/nucleoid/spleef/game/AttributeModifiersConfig.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/AttributeModifiersConfig.java
@@ -1,0 +1,35 @@
+package xyz.nucleoid.spleef.game;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.entity.attribute.EntityAttribute;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+import java.util.List;
+
+public record AttributeModifiersConfig(List<Entry> entries) {
+    public static final AttributeModifiersConfig EMPTY = new AttributeModifiersConfig(List.of());
+    public static final Codec<AttributeModifiersConfig> CODEC = Entry.CODEC.listOf().xmap(AttributeModifiersConfig::new, AttributeModifiersConfig::entries);
+
+    public void applyTo(ServerPlayerEntity player) {
+        for (var entry : this.entries()) {
+            var instance = player.getAttributeInstance(entry.attribute());
+
+            if (instance != null) {
+                instance.removeModifier(entry.modifier().id());
+                instance.addTemporaryModifier(entry.modifier());
+            }
+        }
+    }
+
+    private record Entry(RegistryEntry<EntityAttribute> attribute, EntityAttributeModifier modifier) {
+        public static final Codec<Entry> CODEC = RecordCodecBuilder.create(instance -> {
+            return instance.group(
+                    EntityAttribute.CODEC.fieldOf("type").forGetter(Entry::attribute),
+                    EntityAttributeModifier.MAP_CODEC.forGetter(Entry::modifier)
+            ).apply(instance, Entry::new);
+        });
+    }
+}

--- a/src/main/java/xyz/nucleoid/spleef/game/SpleefActive.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/SpleefActive.java
@@ -1,5 +1,6 @@
 package xyz.nucleoid.spleef.game;
 
+import net.minecraft.entity.attribute.EntityAttributeInstance;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.entity.effect.StatusEffects;
@@ -269,6 +270,8 @@ public final class SpleefActive {
     private void spawnParticipant(ServerPlayerEntity player, int index) {
         player.changeGameMode(GameMode.ADVENTURE);
         player.getInventory().clear();
+
+        this.config.attributeModifiers().applyTo(player);
 
         ItemStack stack = this.config.tool().createStack(player.getServer(), index, this.map);
         if (!stack.isEmpty()) {

--- a/src/main/java/xyz/nucleoid/spleef/game/SpleefActive.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/SpleefActive.java
@@ -15,8 +15,10 @@ import net.minecraft.util.ActionResult;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.BlockCollisionSpliterator;
 import net.minecraft.world.GameMode;
 import org.jetbrains.annotations.Nullable;
 import xyz.nucleoid.map_templates.BlockBounds;
@@ -131,11 +133,13 @@ public final class SpleefActive {
             for (var player : this.gameSpace.getPlayers()) {
                 if (player.isSpectator()) continue;
 
-                var pos = player.getLandingPos().mutableCopy();
-                for (int corner = 0; corner < 4; corner++) {
-                    pos.setX(MathHelper.floor(player.getX() + (corner % 2 * 2 - 1) * 0.25));
-                    pos.setZ(MathHelper.floor(player.getZ() + (corner / 2 % 2 * 2 - 1) * 0.25));
+                var boundingBox = player.getBoundingBox();
+                var box = new Box(boundingBox.minX, boundingBox.minY - MathHelper.EPSILON, boundingBox.minZ, boundingBox.maxX, boundingBox.minY, boundingBox.maxZ);
 
+                var collisions = new BlockCollisionSpliterator<>(player.getWorld(), player, box, false, (pos, voxelShape) -> pos);
+
+                while (collisions.hasNext()) {
+                    var pos = collisions.next();
                     this.map.tryBeginDecayAt(pos, this.config.decay());
                 }
             }

--- a/src/main/java/xyz/nucleoid/spleef/game/SpleefConfig.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/SpleefConfig.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 public record SpleefConfig(
         Either<SpleefGeneratedMapConfig, SpleefTemplateMapConfig> map,
         WaitingLobbyConfig players,
+        AttributeModifiersConfig attributeModifiers,
         ToolConfig tool,
         @Nullable ProjectileConfig projectile,
         @Nullable LavaRiseConfig lavaRise,
@@ -25,6 +26,7 @@ public record SpleefConfig(
     public static final MapCodec<SpleefConfig> CODEC = RecordCodecBuilder.mapCodec(i -> i.group(
         Codec.xor(SpleefGeneratedMapConfig.CODEC, SpleefTemplateMapConfig.CODEC).fieldOf("map").forGetter(SpleefConfig::map),
         WaitingLobbyConfig.CODEC.fieldOf("players").forGetter(SpleefConfig::players),
+        AttributeModifiersConfig.CODEC.optionalFieldOf("attribute_modifiers", AttributeModifiersConfig.EMPTY).forGetter(SpleefConfig::attributeModifiers),
         ToolConfig.CODEC.optionalFieldOf("tool", ToolConfig.DEFAULT).forGetter(SpleefConfig::tool),
         ProjectileConfig.CODEC.optionalFieldOf("projectile").forGetter(config -> Optional.ofNullable(config.projectile())),
         LavaRiseConfig.CODEC.optionalFieldOf("lava_rise").forGetter(config -> Optional.ofNullable(config.lavaRise())),
@@ -37,6 +39,7 @@ public record SpleefConfig(
     private SpleefConfig(
             Either<SpleefGeneratedMapConfig, SpleefTemplateMapConfig> map,
             WaitingLobbyConfig players,
+            AttributeModifiersConfig attributeModifiers,
             ToolConfig tool,
             Optional<ProjectileConfig> projectile,
             Optional<LavaRiseConfig> lavaRise,
@@ -46,7 +49,7 @@ public record SpleefConfig(
             boolean unstableTnt
     ) {
         this(
-                map, players, tool,
+                map, players, attributeModifiers, tool,
                 projectile.orElse(null),
                 lavaRise.orElse(null),
                 levelBreakInterval, decay,

--- a/src/main/java/xyz/nucleoid/spleef/game/SpleefWaiting.java
+++ b/src/main/java/xyz/nucleoid/spleef/game/SpleefWaiting.java
@@ -95,6 +95,8 @@ public final class SpleefWaiting {
                             true,
                             false
                     ));
+
+                    this.config.attributeModifiers().applyTo(player);
                 });
     }
 }


### PR DESCRIPTION
This pull request introduces a `attribute_modifiers` field to the configuration that can be used to apply attribute modifiers to all players:

```json5
{
	"type": "spleef:spleef",
	"attribute_modifiers": [
		{
			"id": "spleef:embiggen",
			"operation": "add_value",
			"type": "minecraft:scale",
			"amount": 1.5
		}
	],
	// ...
}
```

To improve accuracy with differing player scales, a new strategy for detecting collision for decay is used, which fixes #30 as a side effect.